### PR TITLE
Change event when tinymce field is updated

### DIFF
--- a/ux/form/field/TinyMCE.js
+++ b/ux/form/field/TinyMCE.js
@@ -12,6 +12,7 @@
 Ext.define("Ext.ux.form.field.TinyMCE", {
     extend: 'Ext.form.field.TextArea',
     alias: 'widget.tinymcefield',
+    cls: Ext.baseCSSPrefix + "tinymcefield",
 
     requires: ['Ext.ux.form.field.TinyMCEWindowManager'],
 
@@ -142,6 +143,18 @@ Ext.define("Ext.ux.form.field.TinyMCE", {
                 }, 10, me);
 
                 me.fireEvent('editorcreated', me.editor, me);
+                var dirtyFunc = Ext.Function.createBuffered(function () {
+                    var newValue = me.getValue();
+                    if (newValue != me.lastValue) {
+                        me.fireEvent("change", me, me.getValue(), me.lastValue || "");
+                        me.lastValue = me.getValue();
+                    }
+                }, 100);
+
+                me.editor.onEvent.add(dirtyFunc);
+                me.editor.onExecCommand.add(dirtyFunc);
+                me.editor.onSetContent.add(dirtyFunc);
+                me.editor.onChange.add(dirtyFunc);
             });
         };
 
@@ -347,3 +360,4 @@ Ext.define("Ext.ux.form.field.TinyMCE", {
         return true;
     }
 });
+

--- a/ux/form/field/TinyMCE.js
+++ b/ux/form/field/TinyMCE.js
@@ -148,6 +148,9 @@ Ext.define("Ext.ux.form.field.TinyMCE", {
                     if (newValue != me.lastValue) {
                         me.fireEvent("change", me, me.getValue(), me.lastValue || "");
                         me.lastValue = me.getValue();
+                        me.fireEvent("dirtychange", me, true);
+                    } else {
+                        me.fireEvent("dirtychange", me, false);
                     }
                 }, 100);
 


### PR DESCRIPTION
Wanted to say that I really like this plug-in.  I use ExtJS for the front end of a web application I'm using and there were two issues I had that I thought you might like to include in your code.  

The tinymcefield didn't fire change events so it was difficult to respond and set dirty states in stores when using functions line undo, redo, and editing code. 

Also, this is small, but I added a bass class to the field so it can easily distinguished when styling.
