### PR TITLE
ToggleSlide animation error

### DIFF
--- a/ux/toggleslide/ToggleSlide.js
+++ b/ux/toggleslide/ToggleSlide.js
@@ -290,39 +290,41 @@ Ext.define('Ext.ux.toggleslide.ToggleSlide', {
             runner = new Ext.util.TaskRunner(),
             to = on ? me.rightside : 0;
         
-        Ext.create('Ext.fx.Anim', {
-            target: me.handle,
-            dynamic: true,
-            easing: 'easeOut',
-            duration: me.duration,
-            to : {
-                left: to
-            },
-            listeners: {
-                beforeanimate: {
-                    fn: function(ani)
-                    {
-                        me.task = runner.newTask({
-                            run: function () {
-                                me.onDrag();
-                            },
-                            interval: 10
-                        });
-                        me.task.start();
-                    },
-                    scope: this
+        if (me.rendered) {
+            Ext.create('Ext.fx.Anim', {
+                target: me.handle,
+                dynamic: true,
+                easing: 'easeOut',
+                duration: me.duration,
+                to : {
+                    left: to
                 },
-                afteranimate: {
-                    fn: function(ani)
-                    {
-                        me.onDrag();
-                        me.task.destroy();
+                listeners: {
+                    beforeanimate: {
+                        fn: function(ani)
+                        {
+                            me.task = runner.newTask({
+                                run: function () {
+                                    me.onDrag();
+                                },
+                                interval: 10
+                            });
+                            me.task.start();
+                        },
+                        scope: this
                     },
-                    scope: this
-                } 
-            },
-            callback: callback
-        });
+                    afteranimate: {
+                        fn: function(ani)
+                        {
+                            me.onDrag();
+                            me.task.destroy();
+                        },
+                        scope: this
+                    } 
+                },
+                callback: callback
+            });
+        }
     },
     
     /**


### PR DESCRIPTION
Before applying animation, it checks if the component is rendered to prevent js error.
When ToggleSlide form field's value is changed before it is rendered, it causes an error.

To reproduce, 
1. Put a toggleslidefield inside tabpanel's second tab which doesn't show initially. then put the tabpanel inside a formpanel.
2. form.loadRecord to change slidetoggle's value.
