### PR TITLE
uploader: Window modal, beforestart event

### DIFF
--- a/ux/upload/Basic.js
+++ b/ux/upload/Basic.js
@@ -191,13 +191,14 @@ Ext.define('Ext.ux.upload.Basic', {
     start: function()
     {
         var me = this;
-        me.fireEvent('beforestart', me);
-        if(me.multipart_params)
-        {
-            me.uploader.settings.multipart_params = me.multipart_params;
+        if (me.fireEvent('beforestart', me) === true) {
+            if(me.multipart_params)
+            {
+                me.uploader.settings.multipart_params = me.multipart_params;
+            }
+            me.uploader.start();
+            //console.log(me.uploader);
         }
-        me.uploader.start();
-        //console.log(me.uploader);
     },
     
     initializeUploader: function()

--- a/ux/upload/plugin/Window.js
+++ b/ux/upload/plugin/Window.js
@@ -138,7 +138,8 @@ Ext.define('Ext.ux.upload.plugin.Window', {
             title: me.title || 'Upload files',
             width: me.width || 640,
             height: me.height || 380,
-            // modal : true, // harry
+            //modal : true, // harry
+            modal: me.modal,
             plain: true,
             constrain: true,
             border: false,


### PR DESCRIPTION
Dear Harald,

Just updated the Uploader Plugin Window code so that one can configure the Upload progress window modal:

```
{
xtype: 'uploadbutton',
                    plugins: [{
                        ptype: 'ux.upload.window',
                        title: 'Upload',
                        width: 520,
                        pluginId: 'uploadWin',
                        modal: true // <<------------
                    }]
}
```

And, additionally, the uploader's 'beforestart' event handler now can return false to cancel the upload. Useful for checking some pre-requisits, like this:

```
{
  xtype: 'uploadbutton',
  listeners: {
    beforestart: function(uploader) {
      if (isValidSomehow) return true;
      else return false;
    }
  }
}
```
