### PR TITLE
Ext.ux.grid.property.Grid - Fix uncaught type error in 4.2.1

### DIFF
--- a/ux/grid/property/HeaderContainer.js
+++ b/ux/grid/property/HeaderContainer.js
@@ -19,6 +19,7 @@ Ext.define('Ext.ux.grid.property.HeaderContainer', {
     falseText: 'false',
     // private
     nameColumnCls: Ext.baseCSSPrefix + 'grid-property-name',
+    nameColumnInnerCls: Ext.baseCSSPrefix + 'grid-cell-inner-property-name',
     
     /**
      * Creates new HeaderContainer.
@@ -37,7 +38,8 @@ Ext.define('Ext.ux.grid.property.HeaderContainer', {
                 itemId: grid.nameField,
                 menuDisabled: true,
                 groupField: true,
-                tdCls: me.nameColumnCls
+                tdCls: me.nameColumnCls,
+                innerCls: me.nameColumnInnerCls
             },
             {
                 header: me.valueText,
@@ -64,6 +66,7 @@ Ext.define('Ext.ux.grid.property.HeaderContainer', {
         me.grid = grid;
         me.store = store;
         me.callParent([{
+            isRootHeader: true,
             items: columns
         }]);
     },


### PR DESCRIPTION
Update header container with new proprties in 4.2.1 to fix uncaugt type error
